### PR TITLE
Add elasticmapreduce:AddTags permission to DL AWS setup

### DIFF
--- a/aws_datalake/modules/iam/main.tf
+++ b/aws_datalake/modules/iam/main.tf
@@ -58,6 +58,7 @@ data "aws_iam_policy_document" "segment_data_lake_policy_document" {
       "elasticmapreduce:DescribeStep",
       "elasticmapreduce:RunJobFlow",
       "elasticmapreduce:TerminateJobFlows",
+      "elasticmapreduce:AddTags"
     ]
 
     resources = [


### PR DESCRIPTION
Add elasticmapreduce:AddTags permission to DL AWS setup

This is needed when CSE tries to clone customers' EMR clusters when trying to replay the syncs. Typically a temporary cluster is recommended to do the replays because of larger volume - https://segment.atlassian.net/wiki/spaces/CSEng/pages/727482433/AWS+Data+Lakes+Guide+for+Success+Engineering#Running-a-Replay-with-a-dedicated-EMR-cluster. But our customer datalake tool's clone command is failingcurrently because of this missing privilege.

Please see this slack thread for more details - https://twilio.slack.com/archives/CM01LATR8/p1715554934551369