### PR TITLE
Update: Add tag action for EMR

### DIFF
--- a/aws_datalake/modules/iam/main.tf
+++ b/aws_datalake/modules/iam/main.tf
@@ -58,6 +58,7 @@ data "aws_iam_policy_document" "segment_data_lake_policy_document" {
       "elasticmapreduce:DescribeStep",
       "elasticmapreduce:RunJobFlow",
       "elasticmapreduce:TerminateJobFlows",
+      "elasticmapreduce:AddTags"
     ]
 
     resources = [


### PR DESCRIPTION
[WARE-2166](https://segment.atlassian.net/browse/WARE-2166)
## Description
Compare Permissions in IAM role ARN of Data Lakes against roles specified in this [documentation](https://segment.com/docs/connections/storage/data-lakes/data-lakes-manual-setup/) to make sure all roles exists in the IAM ARM as given in Documentation.
# Environment : Stage
### Workspace : Sauron Stage
### ARN : arn:aws:iam::874799288871:role/segment-data-lake-iam-role
### S3 Bucket : datalakes-test-dev
### Sources Where Sync is Successfully Running and Active
1. low-volume
2. storage-destinations (No Data Rows Have Been Synced So Far)
3. high-volume  (No Data Rows Have Been Synced So Far, Last sync failed EMR cluster in setting does not exist)
Comments: No Changes required as all the permissions mentioned in doc exists for the IAM ARN given above.

# Environment : Prod
### Workspace: Segment Sauron
### ARN : arn:aws:iam::294048959147:role/SegmentDataLakeRole
### S3 Bucket : segment-datalakes-testing
### Sources Where Sync is Successfully Running and Active
1. DataLakes
2. ios prod
3. S3 / Data Lakes / Personas source
4. Warehouse Compatibility Mode
5. job_track_100eps
Comments: Added the missing "elasticmapreduce:AddTags" permission to the above IAM ARN.

[WARE-2166]: https://segment.atlassian.net/browse/WARE-2166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ